### PR TITLE
add docker integration settings

### DIFF
--- a/manifests/os.pp
+++ b/manifests/os.pp
@@ -25,6 +25,8 @@ define newrelic::os (
   $docker_cert        = '',
   $docker_key         = '',
   $docker_cacert      = '',
+  $cgroup_root        = '',
+  $cgroup_style       = '',
 ){
   case $::osfamily {
     'RedHat', 'Debian': { $package_name = 'newrelic-sysmond'}

--- a/templates/nrsysmond.cfg.erb
+++ b/templates/nrsysmond.cfg.erb
@@ -31,3 +31,5 @@ ssl_ca_bundle=<%= @ssl_ca_bundle %>
 <% if !@docker_cert.empty? %>docker_cert=<%= @docker_cert %><% end -%>
 <% if !@docker_key.empty? %>docker_key=<%= @docker_key %><% end -%>
 <% if !@docker_cacert.empty? %>docker_cacert=<%= @docker_cacert %><% end -%>
+<% if !@cgroup_root.empty? %>cgroup_root=<%= @cgroup_root %><% end -%>
+<% if !@cgroup_style.empty? %>cgroup_style=<%= @cgroup_style %><% end -%>


### PR DESCRIPTION
Allows us to set this stuff correctly:

https://docs.newrelic.com/docs/servers/new-relic-servers-linux/installation-configuration/install-other-linux-new-relic-servers